### PR TITLE
added namespace to android gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "io.github.parassharmaa.usage_stats"    
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
In order to upgrade AGP, we have to set the namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Android build configuration with namespace declaration for the library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->