### PR TITLE
Fix build errors with flutter 3.29.0

### DIFF
--- a/android/src/main/kotlin/io/github/parassharmaa/usage_stats/UsageStatsPlugin.kt
+++ b/android/src/main/kotlin/io/github/parassharmaa/usage_stats/UsageStatsPlugin.kt
@@ -8,7 +8,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -22,23 +21,13 @@ public class UsageStatsPlugin : FlutterPlugin, MethodCallHandler {
     private var mContext: Context? = null
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "usage_stats")
-        channel.setMethodCallHandler(this);
+        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "usage_stats")
+        channel.setMethodCallHandler(this)
         setContext(flutterPluginBinding.applicationContext)
     }
 
     private fun setContext(context: Context) {
         this.mContext = context
-    }
-
-    companion object {
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), "usage_stats")
-            var plugin = UsageStatsPlugin()
-            plugin.setContext(registrar.context())
-            channel.setMethodCallHandler(plugin)
-        }
     }
 
     override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {


### PR DESCRIPTION
#32: Fix build errors with flutter 3.29.0 due to the [removal of v1 Android embedding Java APIs](https://docs.flutter.dev/release/breaking-changes/v1-android-embedding) by removing the deprecated `Registrar`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Modernized the plugin registration process to align with the current Flutter framework.
  
- **Chore**
  - Removed outdated registration methods to streamline initialization and ensure improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->